### PR TITLE
Make use of the SYCL queue passed to CUTLASS

### DIFF
--- a/torch/_inductor/codegen/xpu/sycl_kernel.py
+++ b/torch/_inductor/codegen/xpu/sycl_kernel.py
@@ -154,8 +154,7 @@ class SYCLTemplateKernel(SYCLKernel):
     Template kernels defined by SYCL / Cutlass in C++.
     """
 
-    # TODO (SYCL): The SYCL queue is not being used
-    _EXTRA_CPP_ARGS = "size_t* workspace_size, uint8_t* workspace, sycl::queue stream"
+    _EXTRA_CPP_ARGS = "size_t* workspace_size, uint8_t* workspace, sycl::queue* stream"
 
     def __init__(
         self,


### PR DESCRIPTION
Use the SYCL queue passed to the function generated for SYCL CUTLASS.

It is used for two purposes:
- Get the compute unit count of the device actually used
- Pass to GemmUniversialAdapter run and initialize for sync.

This addresses some of the items left open after #2.
